### PR TITLE
Encoder fix

### DIFF
--- a/Arduino/Encoder.cpp
+++ b/Arduino/Encoder.cpp
@@ -12,6 +12,17 @@ Encoder::Encoder(int8_t aPin, int8_t bPin, void (*callback)())
   attachInterrupt(aPin, callback, FALLING);
 }
 
+Encoder::Encoder(int8_t aPin, int8_t bPin)
+{
+  pinMode(aPin, INPUT_PULLUP);
+  pinMode(bPin, INPUT_PULLUP);
+
+  m_aPin = aPin;
+  m_bPin = bPin;
+
+  m_lastA = digitalRead(aPin);
+}
+
 int Encoder::poll()
 {
   int8_t A = digitalRead(m_aPin);

--- a/Arduino/Encoder.h
+++ b/Arduino/Encoder.h
@@ -6,6 +6,7 @@ class Encoder
 {
 public:
   	Encoder(int8_t aPin, int8_t bPin, void (*callbackr)());
+    Encoder(int8_t aPin, int8_t bPin);
     int poll(void);
     int read(void);
     void isr(void);


### PR DESCRIPTION
sketch doesn't compile because the library expects a callback function.  since sketch uses polling, this patch adds an option for no callback to the library.
